### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,4 +125,4 @@ Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.
 
 To generate htpasswd file, run this docker command:
-`docker run --entrypoint htpasswd registry:2 -Bbn user password > ./htpasswd`.
+`docker run --entrypoint htpasswd httpd:2 -Bbn user password > ./htpasswd`.


### PR DESCRIPTION
This registry container does not have htpasswd in it.  httpd does.  Recommend changing so that documentation is usable.